### PR TITLE
Extract outline component

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,12 +321,6 @@ fn extract_mask_camera_phase(
     }
 }
 
-fn extract_outline_mesh(mut commands: Commands, cameras: Extract<Query<(Entity, &Outline)>>) {
-    for (entity, outline) in cameras.iter() {
-        commands.get_or_spawn(entity).insert(outline.clone());
-    }
-}
-
 fn queue_mesh_masks(
     mesh_mask_draw_functions: Res<DrawFunctions<MeshMask>>,
     mesh_mask_pipeline: Res<MeshMaskPipeline>,


### PR DESCRIPTION
The outline component was never extracted which means the outline is always applied to everything. This was probably an artifact of the update to 0.8.

I also fixed a bug where the app would crash when using more than one camera because it was using unwrap instead of returning when the query failed.