### PR TITLE
Bevy 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ bitflags = "1"
 wgpu-profiler = { version = "0.9", optional = true }
 
 [dependencies.bevy]
-version = "0.8.0"
+version = "0.9.0"
 default-features = false
 features = [
     "bevy_asset",

--- a/examples/cube/Cargo.toml
+++ b/examples/cube/Cargo.toml
@@ -5,5 +5,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.8.0" }
+bevy = { version = "0.9.0" }
 bevy_jfa = { path = "../.." }

--- a/examples/cube/src/main.rs
+++ b/examples/cube/src/main.rs
@@ -21,51 +21,55 @@ fn setup(
         ..Default::default()
     });
 
-    commands
-        .spawn_bundle(PbrBundle {
+    commands.spawn((
+        PbrBundle {
             mesh: mesh.clone(),
             material: material.clone(),
             transform: Transform::from_xyz(0.0, 0.0, 0.0),
             ..Default::default()
-        })
-        .insert(RotationAxis(Vec3::Y))
-        .insert(Outline { enabled: true });
+        },
+        RotationAxis(Vec3::Y),
+        Outline { enabled: true },
+    ));
 
-    commands
-        .spawn_bundle(PbrBundle {
+    commands.spawn((
+        PbrBundle {
             mesh: mesh.clone(),
             material: material.clone(),
             transform: Transform::from_xyz(-2.0, 0.0, 0.0),
             ..Default::default()
-        })
-        .insert(RotationAxis(Vec3::X))
-        .insert(Outline { enabled: true });
+        },
+        RotationAxis(Vec3::X),
+        Outline { enabled: true },
+    ));
 
-    commands
-        .spawn_bundle(PbrBundle {
+    commands.spawn((
+        PbrBundle {
             mesh,
             material,
             transform: Transform::from_xyz(0.0, 0.0, -2.0),
             ..Default::default()
-        })
-        .insert(RotationAxis(Vec3::Z))
-        .insert(Outline { enabled: true });
+        },
+        RotationAxis(Vec3::Z),
+        Outline { enabled: true },
+    ));
 
-    commands
-        .spawn_bundle(Camera3dBundle {
+    commands.spawn((
+        Camera3dBundle {
             transform: Transform::from_xyz(3.0, 2.0, 3.0)
                 .looking_at([-1.0, -0.5, -1.0].into(), Vec3::Y),
             ..Camera3dBundle::default()
-        })
-        .insert(CameraOutline {
+        },
+        CameraOutline {
             enabled: true,
             style: outline_styles.add(OutlineStyle {
                 color: Color::hex("b4a2c8").unwrap(),
                 width: 33.0,
             }),
-        });
+        },
+    ));
 
-    commands.spawn_bundle(PointLightBundle {
+    commands.spawn(PointLightBundle {
         point_light: PointLight {
             color: Color::WHITE,
             intensity: 800.0,

--- a/src/jfa.rs
+++ b/src/jfa.rs
@@ -42,6 +42,7 @@ impl Dimensions {
     }
 }
 
+#[derive(Resource)]
 pub struct JfaPipeline {
     cached: CachedRenderPipelineId,
 }

--- a/src/jfa_init.rs
+++ b/src/jfa_init.rs
@@ -15,6 +15,7 @@ use bevy::{
 
 use crate::{resources::OutlineResources, JFA_INIT_SHADER_HANDLE, JFA_TEXTURE_FORMAT};
 
+#[derive(Resource)]
 pub struct JfaInitPipeline {
     cached: CachedRenderPipelineId,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ const FULLSCREEN_PRIMITIVE_STATE: PrimitiveState = PrimitiveState {
 pub struct OutlinePlugin;
 
 /// Performance and visual quality settings for JFA-based outlines.
-#[derive(Clone, ExtractResource)]
+#[derive(Clone, Resource, ExtractResource)]
 pub struct OutlineSettings {
     pub(crate) half_resolution: bool,
 }

--- a/src/mask.rs
+++ b/src/mask.rs
@@ -17,6 +17,7 @@ use bevy::{
 
 use crate::{resources::OutlineResources, MeshMask, MASK_SHADER_HANDLE};
 
+#[derive(Resource)]
 pub struct MeshMaskPipeline {
     mesh_pipeline: MeshPipeline,
 }

--- a/src/outline.rs
+++ b/src/outline.rs
@@ -45,7 +45,7 @@ pub struct GpuOutlineParams {
     pub(crate) bind_group: BindGroup,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Resource)]
 pub struct OutlinePipeline {
     dimensions_layout: BindGroupLayout,
     input_layout: BindGroupLayout,

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -22,6 +22,7 @@ const JFA_FROM_PRIMARY: &str = "jfa_from_primary_output_bind_group";
 const JFA_FROM_SECONDARY: &str = "jfa_from_secondary_output_bind_group";
 const JFA_OUTLINE_SRC: &str = "jfa_outline_src_bind_group";
 
+#[derive(Resource)]
 pub struct OutlineResources {
     // Multisample target for initial mask pass.
     pub mask_multisample: CachedTexture,


### PR DESCRIPTION
# Objective

bumb to `bevy` 0.9

# Issues

Launching the example we have wgpu error:

```
2022-11-13T11:16:16.956602Z ERROR wgpu::backend::direct: Handling wgpu errors as fatal by default
thread 'main' panicked at 'wgpu error: Validation Error

Caused by:
    In a RenderPass
      note: encoder = `<CommandBuffer-(0, 1, Metal)>`
    In a set_pipeline command
      note: render pipeline = `jfa_outline_pipeline`
    Render pipeline targets are incompatible with render pass
    Incompatible color attachment: the renderpass expected [Some(Bgra8UnormSrgb)] but was given [Some(Rgba8UnormSrgb)]

', /me/.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-0.14.0/src/backend/direct.rs:2403:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-[_MTLCommandEncoder dealloc]:131: failed assertion `Command encoder released without endEncoding'
```